### PR TITLE
Add attribute rdf:about in dcat:Dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The available parameters in the camel-oai-pmh.properties file are:
 * oai-pmh.base.url.external: URL that external clients use to access the OAI-PMH interface web application
 * oai-pmh.rdf.catalog.base.url: Endpoint where the DCAT-AP.de RDF catalog should be reachable
 * oai-pmh.dcatde.contributorID: [dcatde:contributorID](https://www.dcat-ap.de/def/contributors/) which is to be inserted in all DCAT datasets
+* oai-pmh.csw.serviceShowMetadata.URL: Base URL for the `rdf:about` attribute of DCAT Dataset elements. The URL may contain a placeholder of the form `%uid%`, which gets replaced by the dataset ID. If there is no placeholder, the ID gets appended with a "#".
 * oai-pmh.db.item.csw.TYPE: should be one of inspire, inspireSoap11 or inspireSoap11, depending on the protocol of the Geoportal
 * oai-pmh.db.item.csw.URL: GetRecords URL of the geoportal to be harvested
 * oai-pmh.db.item.csw.sortResults: toggle whether the results should be sorted or not. Possible values are `true` and `false`. Defaults to `false`.

--- a/build.properties.sample
+++ b/build.properties.sample
@@ -8,4 +8,6 @@ oai-pmh.db.item.ckan.URL=https://localhost:9090
 
 oai-pmh.dcatde.contributorID=http://dcat-ap.de/def/contributors/gdiDE
 
+oai-pmh.csw.serviceShowMetadata.URL=https://localhost:8080/inspire/srv/eng/xml_iso19139?uuid=%uid%
+
 oai-pmh.log.file=${catalina.base}/logs/open-nrw-ci-fassaden.log

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@
         <oai-pmh.db.item.ckan.TYPE>ckan</oai-pmh.db.item.ckan.TYPE>
         <oai-pmh.db.item.ckan.URL>https://localhost:9090</oai-pmh.db.item.ckan.URL>
         <oai-pmh.dcatde.contributorID>http://dcat-ap.de/def/contributors/gdiDE</oai-pmh.dcatde.contributorID>
+        <oai-pmh.csw.serviceShowMetadata.URL>https://localhost:8080/inspire/srv/eng/xml_iso19139?uuid=%uid%</oai-pmh.csw.serviceShowMetadata.URL>
         <oai-pmh.log.file>/var/log/inspire-bridge/inspire-bridge.log</oai-pmh.log.file>
     </properties>
     <profiles>

--- a/src/main/resources/camel-oai-pmh.properties
+++ b/src/main/resources/camel-oai-pmh.properties
@@ -6,3 +6,4 @@ db.item.csw.sortResults=${oai-pmh.db.item.csw.sortResults}
 db.item.ckan.TYPE=${oai-pmh.db.item.ckan.TYPE}
 db.item.ckan.URL=${oai-pmh.db.item.ckan.URL}
 dcatde.contributorID=${oai-pmh.dcatde.contributorID}
+csw.serviceShowMetadata.URL=${oai-pmh.csw.serviceShowMetadata.URL}

--- a/src/main/resources/camel-oai-pmh.xml
+++ b/src/main/resources/camel-oai-pmh.xml
@@ -93,6 +93,9 @@
             <setHeader headerName="contributorID">
                 <simple>{{dcatde.contributorID}}</simple>
             </setHeader>
+            <setHeader headerName="cswServiceShowMetadataBaseUrl">
+                <simple>{{csw.serviceShowMetadata.URL}}</simple>
+            </setHeader>
             <setHeader headerName="sortResults">
                 <simple>{{db.item.csw.sortResults}}</simple>
             </setHeader>
@@ -249,6 +252,9 @@
             </setHeader>
             <setHeader headerName="contributorID">
                 <simple>{{dcatde.contributorID}}</simple>
+            </setHeader>
+            <setHeader headerName="cswServiceShowMetadataBaseUrl">
+                <simple>{{csw.serviceShowMetadata.URL}}</simple>
             </setHeader>
             <removeHeader headerName="resumptionToken"/>
             <removeHeader headerName="cookie"/>

--- a/src/main/resources/iso2dcat.xsl
+++ b/src/main/resources/iso2dcat.xsl
@@ -31,6 +31,8 @@
 
     <!-- Parameters from route -->
     <xsl:param name="contributorID"/>
+    <xsl:param name="cswServiceShowMetadataBaseUrl"/>
+    <xsl:param name="CamelHttpUri"/>
 
     <!--
     <xsl:strip-space elements="*"/>
@@ -41,6 +43,8 @@
 
     <xsl:variable name="tokeDcatAp">:dcat_ap:</xsl:variable>
     <xsl:variable name="prefixDcatAp">dcat_ap</xsl:variable>
+
+    <xsl:variable name="uidPlaceholder">%uid%</xsl:variable>
 
     <xsl:variable name="mdrFileTypes" select="document('filetypes-skos.rdf')"/>
     <xsl:variable name="ianaMediaTypes" select="document('iana-media-types.xml')"/>
@@ -65,6 +69,8 @@
 
     <xsl:template match="gmd:MD_Metadata|gmi:MI_Metadata">
         <dcat:Dataset>
+            <!--rdf:about-->
+            <xsl:call-template name="datasetURI"/>
             <!--dct:description-->
             <!--dct:title-->
             <!--dcatde:contributorID-->
@@ -152,6 +158,26 @@
 
             <xsl:call-template name="dcatTheme"/>
         </dcat:Dataset>
+    </xsl:template>
+
+    <xsl:template name="datasetURI">
+        <xsl:variable name="identifier" select="string(gmd:fileIdentifier/gco:CharacterString)"/>
+        <xsl:if test="$identifier">
+            <xsl:variable name="metadataUri" select="replace($cswServiceShowMetadataBaseUrl, ' ', '')"/>
+            <xsl:choose>
+                <xsl:when test="$metadataUri != '' and contains($metadataUri, $uidPlaceholder)">
+                    <xsl:attribute name="rdf:about"><xsl:value-of select="replace($metadataUri, $uidPlaceholder, $identifier)"/></xsl:attribute>
+                </xsl:when>
+                <xsl:when test="$metadataUri != ''">
+                    <!-- Concat with identifier -->
+                    <xsl:attribute name="rdf:about"><xsl:value-of select="concat($metadataUri, '#', $identifier)"/></xsl:attribute>
+                </xsl:when>
+                <!-- Fallback with service url -->
+                <xsl:otherwise>
+                    <xsl:attribute name="rdf:about"><xsl:value-of select="concat($CamelHttpUri, '#', $identifier)"/></xsl:attribute>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="contributorID">


### PR DESCRIPTION
Adds the `rdf:about` attribute to `dcat:Dataset` elements.

The base URL can be configured via a new parameter. The dataset ID is inserted into this URL either via a placeholder or at the end.