### PR TITLE
support for dct:temporal

### DIFF
--- a/src/main/resources/iso2dcat.xsl
+++ b/src/main/resources/iso2dcat.xsl
@@ -128,6 +128,9 @@
             <!--dct:spatial-->
             <xsl:apply-templates select="gmd:identificationInfo[1]/*/gmd:extent/*/gmd:geographicElement|gmd:identificationInfo/*/srv:extent/*/gmd:geographicElement"/>
 
+            <!--dct:temporal-->
+            <xsl:apply-templates select="gmd:identificationInfo[1]/*/gmd:extent/*/gmd:temporalElement|gmd:identificationInfo/*/srv:extent/*/gmd:temporalElement"/>
+
             <!--dct:issued dct:modified-->
             <xsl:apply-templates select="gmd:dateStamp"/>
             <xsl:apply-templates select="gmd:identificationInfo[1]/*/gmd:citation/*/gmd:date/*[gmd:dateType/*/@codeListValue='publication' or gmd:dateType/*/@codeListValue='revision' or gmd:dateType/*/@codeListValue='creation']/gmd:date/*"/>
@@ -361,6 +364,24 @@
             </dct:spatial>
         </xsl:if>
     </xsl:template>
+
+    <xsl:template match="gmd:identificationInfo/*/gmd:extent/*/gmd:temporalElement|gmd:identificationInfo/*/srv:extent/*/gmd:temporalElement">
+            <dct:temporal>
+                <dct:PeriodOfTime>
+                    <xsl:if test="./gmd:EX_TemporalExtent/gmd:extent/*:TimePeriod/*:beginPosition">
+                        <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
+                            <xsl:value-of select="./gmd:EX_TemporalExtent/gmd:extent/*:TimePeriod/*:beginPosition"/>
+                        </schema:startDate>
+                    </xsl:if>
+                    <xsl:if test="./gmd:EX_TemporalExtent/gmd:extent/*:TimePeriod/*:endPosition">
+                        <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
+                            <xsl:value-of select="./gmd:EX_TemporalExtent/gmd:extent/*:TimePeriod/*:endPosition"/>
+                        </schema:endDate>
+                    </xsl:if>
+                </dct:PeriodOfTime>
+            </dct:temporal>
+    </xsl:template>
+
 
     <xsl:template match="gmd:extent/*/gmd:description/gco:CharacterString">
         <rdfs:label>


### PR DESCRIPTION
I have added support for the temporal coverage of a dataset. 

The original metadata contains an `gmd:temporalElement` as a sibling of `gmd:geographicElement` like this:

```xml
<gmd:temporalElement>
  <gmd:EX_TemporalExtent>
    <gmd:extent>
      <gml:TimePeriod gml:id="timePeriod_ID_b6a9b32e-6781-4dbe-82c0-7a880d72021e">
        <gml:beginPosition>2005-01-01T00:00:00.000+01:00</gml:beginPosition>
        <gml:endPosition>2015-12-31T00:00:00.000+01:00</gml:endPosition>
      </gml:TimePeriod>
    </gmd:extent>
  </gmd:EX_TemporalExtent>
</gmd:temporalElement>
```

It is transformed into:

```xml
<dct:temporal>
  <dct:PeriodOfTime>
    <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2005-01-01T00:00:00.000+01:00</schema:startDate>
    <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-12-31T00:00:00.000+01:00</schema:endDate>
  </dct:PeriodOfTime>
</dct:temporal>
```