### PR TITLE
Integrate OWASP Dependency Check into build system and bump depedencies to avoid known vulnerabilities.

### DIFF
--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <!-- Java deserialization is not used for untrusted data, remote data is exclusively XML. //-->
+    <suppress>
+        <notes><![CDATA[
+        file name: spring-web-5.3.27.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <!-- YAML parsing is not used for untrusted data, remote data is exclusively XML. //-->
+    <suppress>
+        <notes><![CDATA[
+        file name: snakeyaml-1.30.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cpe>cpe:/a:snakeyaml_project:snakeyaml</cpe>
+    </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,23 @@
                     <argLine>-Xms256m -Xmx256m</argLine>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>8.2.1</version>
+                <executions>
+                  <execution>
+                      <goals>
+                          <goal>check</goal>
+                      </goals>
+                  </execution>
+                </executions>
+                <configuration>
+                    <suppressionFiles>
+                        <suppressionFile>dependency-check-suppression.xml</suppressionFile>
+                    </suppressionFiles>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -223,9 +240,9 @@
         </pluginManagement>
     </build>
     <properties>
-        <camel.version>3.14.6</camel.version>
-        <spring-boot.version>2.6.11</spring-boot.version>
-        <log4j.version>2.19.0</log4j.version>
+        <camel.version>3.14.7</camel.version>
+        <spring-boot.version>2.7.11</spring-boot.version>
+        <log4j.version>2.20.0</log4j.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
[OWASP dependency check](https://owasp.org/www-project-dependency-check/) will run during `mvn verify` to check the dependency closure for known vulnerabilities. This is not always accurate as the included suppression file shows as some usage scenarios do not affect the concrete usage within the project. (And CVE-2016-1000027 is basically a WONTFIX from upstream and was declared out of scope.)

Bumping the Spring Boot version alone seems to resolve all known vulnerabilities, expect for the two suppressions.