### PR TITLE
Fix selecting MD_Identifier

### DIFF
--- a/src/main/resources/iso2dcat.xsl
+++ b/src/main/resources/iso2dcat.xsl
@@ -169,13 +169,14 @@
     </xsl:template>
 
     <xsl:template name="datasetURI">
-        <xsl:variable name="identifier" select="string(gmd:identificationInfo[1]/*/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString)"/>
+        <xsl:variable name="identifier" select="gmd:identificationInfo[1]/*/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString"/>
+        <xsl:variable name="identifierString" select="if (count($identifier) &gt; 1) then string($identifier[1]) else string($identifier)"/>
         <xsl:variable name="fileIdentifier" select="string(gmd:fileIdentifier/gco:CharacterString)"/>
         <xsl:variable name="metadataUri" select="replace($cswServiceShowMetadataBaseUrl, ' ', '')"/>
         <xsl:choose>
-            <xsl:when test="starts-with($identifier, 'http')">
+            <xsl:when test="starts-with($identifierString, 'http')">
                 <xsl:attribute name="rdf:about">
-                    <xsl:value-of select="$identifier"/>
+                    <xsl:value-of select="$identifierString"/>
                 </xsl:attribute>
             </xsl:when>
             <xsl:when test="$metadataUri != '' and contains($metadataUri, $uidPlaceholder)">


### PR DESCRIPTION
Uses the first Element MD_Identifier found in the ISO-Metadata.