### PR TITLE
Add charset-Parameter to content-type in coupled services route

### DIFF
--- a/src/main/resources/camel-oai-pmh.xml
+++ b/src/main/resources/camel-oai-pmh.xml
@@ -191,7 +191,7 @@
                 </when>
                 <otherwise>
                     <setHeader name="Content-Type">
-                        <constant>application/xml</constant>
+                        <constant>application/xml;charset=UTF-8</constant>
                     </setHeader>
                 </otherwise>
             </choice>


### PR DESCRIPTION
In the log file we have detected a "400 Bad Request" error entry due to an incorrect request when "reloading" the associated service metadata into the data-metadata. Distributions are often created from the service metadata and added to the metadata. If the service metadata cannot be read, distributions cannot subsequently be created from it.

The reason for the "400 Bad Request", was a URI with an umlaut in combination with the wrong encoding, ISO-8859-1 instead of UTF-8. It seems that the default behavior of the HTTP client used changed with the upgrade of Apache Camel from version 2 to version 3.

The fix explicitly specifies "UTF-8" as the encoding in coupled services route for the service metadata reload query.