### PR TITLE
Add support for High-Value Datasets

### DIFF
--- a/src/main/resources/hvd-categories.rdf
+++ b/src/main/resources/hvd-categories.rdf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<!-- refer to http://data.europa.eu/bna/asd487ae75  -->
+    <hvdCategories>
+        <hvdCategory name="georaum" url="http://data.europa.eu/bna/c_ac64a52d"/>
+        <hvdCategory name="erdbeobachtung und umwelt" url="http://data.europa.eu/bna/c_dd313021"/>
+        <hvdCategory name="meteorologie" url="http://data.europa.eu/bna/c_164e0bf5"/>
+        <hvdCategory name="statistik" url="http://data.europa.eu/bna/c_e1da4e07"/>
+        <hvdCategory name="unternehmen und eigentümerschaft von unternehmen" url="http://data.europa.eu/bna/c_a9135398"/>
+        <hvdCategory name="mobilität" url="http://data.europa.eu/bna/c_b79e35eb"/>
+    </hvdCategories>
+</rdf:RDF>


### PR DESCRIPTION
This adds support for the translation of high value dataset information from ISO to DCAT-AP.

Example:
```
<gmd:descriptiveKeywords>
<gmd:MD_Keywords>
<gmd:keyword>
<gco:CharacterString>Georaum</gco:CharacterString>
</gmd:keyword>
...
<gmd:thesaurusName>
<gmd:CI_Citation>
<gmd:title>
<gco:CharacterString>High-value dataset categories</gco:CharacterString>
</gmd:title>
<gmd:date>
<gmd:CI_Date>
<gmd:date>
<gco:Date>2023-09-27</gco:Date>
</gmd:date>
<gmd:dateType>
<gmd:CI_DateTypeCode codeList="https://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
</gmd:dateType>
</gmd:CI_Date>
</gmd:date>
...
</gmd:CI_Citation>
</gmd:thesaurusName>
</gmd:MD_Keywords>
</gmd:descriptiveKeywords>
```
is returned as
```
<dcat:Dataset ...
<dcatap:applicableLegislation rdf:resource="http://data.europa.eu/eli/reg_impl/2023/138/oj"/>
<dcatap:hvdCategory rdf:resource="http://data.europa.eu/bna/c_ac64a52d"/>
```
