### PR TITLE
Use compliant frequency codelist for dcat:accrualPeriodicity

### DIFF
--- a/src/main/resources/iso2dcat.xsl
+++ b/src/main/resources/iso2dcat.xsl
@@ -1226,8 +1226,12 @@
         <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/UNKNOWN"/>
     </xsl:template>
 
-    <xsl:template match="gmd:maintenanceAndUpdateFrequency/*/@codeListValue[.='asNeeded' or .='notPlanned']">
-        <dct:accrualPeriodicity rdf:resource="{concat('http://inspire.ec.europa.eu/metadata-codelist/MaintenanceFrequencyCode/', .)}"/>
+    <xsl:template match="gmd:maintenanceAndUpdateFrequency/*/@codeListValue[.='asNeeded']">
+        <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/AS_NEEDED"/>
+    </xsl:template>
+
+    <xsl:template match="gmd:maintenanceAndUpdateFrequency/*/@codeListValue[.='notPlanned']">
+        <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/NOT_PLANNED"/>
     </xsl:template>
 
     <xsl:template name="dcatTheme">


### PR DESCRIPTION
Using the INSPIRE codelist for dcat:accrualPeriodicity is not DCAT-AP.de compliant, so this replaces those mappings with ones from the compliant EU vocabulary.

Unfortunately I can't test this change on my work machine, but I felt a PR is more helpful than opening an issue.

In case of approval I would appreciate it if https://gitlab.opencode.de/connected-urban-twins/dcat-de-bridge-leipzig is synced with the upstream changes, as we were informed by the Saxonian Open Data portal that they won't harvest our DCAT catalog with non-compliant entries.
